### PR TITLE
Bump ImmortalWRT to version v24.10.0-rc3

### DIFF
--- a/.github/workflows/immortalwrt-builder-selfhost.yml
+++ b/.github/workflows/immortalwrt-builder-selfhost.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   REPO_URL: https://github.com/immortalwrt/immortalwrt
-  REPO_BRANCH: 24.10.0-rc2
+  REPO_BRANCH: 24.10.0-rc3
   FEEDS_CONF: feeds.conf.default
   CONFIG_FILE: .config
   DIY_P1_SH: diy-part1.sh


### PR DESCRIPTION
This pull request bumps ImmortalWRT to the latest version: v24.10.0-rc3.

Changes:
- Updated `REPO_BRANCH:` to `v24.10.0-rc3` in `.github/workflows/immortalwrt-builder-*.yml`.