### PR TITLE
Bump ImmortalWRT to version v24.10.0-rc3

### DIFF
--- a/.github/workflows/immortalwrt-builder-selfhost.yml
+++ b/.github/workflows/immortalwrt-builder-selfhost.yml
@@ -33,7 +33,7 @@ on:
 
 env:
   REPO_URL: https://github.com/immortalwrt/immortalwrt
-  REPO_BRANCH: ${{ github.event.inputs.version_system }}
+  REPO_BRANCH: 24.10.0-rc3
   FEEDS_CONF: feeds.conf.default
   CONFIG_FILE: config/${{ github.event.inputs.release_type }}/.config
   DIY_P1_SH: diy-part1.sh


### PR DESCRIPTION
This pull request updates the ImmortalWRT version to **v24.10.0-rc3**.

Changes included:
{% if env.repo_branch_needs_update == 'true' %}
- Updated `REPO_BRANCH` in the following files:
  .github/workflows/immortalwrt-builder-selfhost.yml
{% endif %}
{% if env.config_repo_needs_update == 'true' %}
- Updated `CONFIG_VERSION_REPO` in `.config`.
{% endif %}
{% if env.version_needs_update == 'true' %}
- Updated `VERSION` in `scripts/update-script.sh`.
{% endif %}

Labels: bump, immortalwrt, nightly, v24.10.0-rc3