### PR TITLE
Bump ImmortalWRT to version v24.10.0-rc4

### DIFF
--- a/scripts/update-script.sh
+++ b/scripts/update-script.sh
@@ -44,8 +44,8 @@ version_greater() {
 }
 
 check_and_update_compat_version() {
-  REQUIRED_VERSION="$1"
-  CURRENT_VERSION=$(uci get system.@system[0].compat_version 2>/dev/null || echo "0.0")
+  REQUIRED_VERSION=24.10.0-rc4
+  CURRENT_VERSION=24.10.0-rc4
 
   if version_greater "$REQUIRED_VERSION" "$CURRENT_VERSION"; then
     log_info "Updating compat_version from $CURRENT_VERSION to $REQUIRED_VERSION..."
@@ -105,7 +105,7 @@ SYSUPGRADE_LOG=$(sysupgrade -T "$SYSUPGRADE_IMG" 2>&1)
 echo "$SYSUPGRADE_LOG"
 
 if echo "$SYSUPGRADE_LOG" | grep -q "The device is supported, but the config is incompatible"; then
-  REQUIRED_VERSION=$(echo "$SYSUPGRADE_LOG" | grep "incompatible" | awk -F'->' '{print $2}' | awk -F')' '{print $1}' | tr -d '[:space:]')
+  REQUIRED_VERSION=24.10.0-rc4
   if [ -n "$REQUIRED_VERSION" ]; then
     log_info "Detected required compat_version: $REQUIRED_VERSION"
     check_and_update_compat_version "$REQUIRED_VERSION"


### PR DESCRIPTION
This pull request updates the ImmortalWRT version to **v24.10.0-rc4**.

Changes included:
{% if env.repo_branch_needs_update == 'true' %}
- Updated `REPO_BRANCH` in the following files:
  
{% endif %}
{% if env.config_repo_needs_update == 'true' %}
- Updated `CONFIG_VERSION_REPO` in `.config`.
{% endif %}
{% if env.version_needs_update == 'true' %}
- Updated `VERSION` in `scripts/update-script.sh`.
{% endif %}

Labels: bump, immortalwrt, nightly, v24.10.0-rc4