### PR TITLE
docs: Update CHANGELOG for 2025-04-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to **BananaWRT** will be documented in this file.
 
 ---
 
+## [2025-04-17]
+
+### 🍌 BananaWRT Core
+
+- 🐛 CHANGELOG: fixing some issues 1 by @SuperKali  
+- 🐛 CHANGELOG: fixing some issues by @SuperKali  
+- 🐛 CHANGELOG: fix issue on formatting commit message by @SuperKali  
+- ➕ CHANGELOG: Adding automatic changelog updater by @SuperKali  
+- 🔼 Bump ImmortalWRT to version v24.10.1 (#40) by @SuperKali  
+- ➕ CHANGELOG: added the release of 2025-04-16 by @SuperKali  
+
+---
+
+
 ## [2025-04-16]
 
 ### 🧩 Additional Packages
@@ -85,4 +99,4 @@ All notable changes to **BananaWRT** will be documented in this file.
 ---
 
 🛠️ Maintained with ❤️ by [BananaWRT](https://github.com/SuperKali/BananaWRT)  
-📅 Release date: **April 16, 2025**
+📅 Release date: **April 17, 2025**


### PR DESCRIPTION
This PR automatically updates the CHANGELOG.md with the latest changes.

## Changes included:
- Additions from BananaWRT core repository
- Additions from openwrt-packages repository

Please review the changes to ensure they're correctly formatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog with a new entry for April 17, 2025, highlighting recent fixes and enhancements to BananaWRT Core.
  - Documented the addition of an automatic changelog updater and a version update to ImmortalWRT v24.10.1.
  - Included the previous release from April 16, 2025, and updated the release date accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->