### PR TITLE
docs: Update CHANGELOG for 2025-06-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to **BananaWRT** will be documented in this file.
 
 ---
+## [2025-06-19]
+
+### 🧩 Additional Packages
+
+- 🐛 3ginfo: fix netdrv value to retrieve qmi protocol for fibocom fm160 by @SuperKali  
+- ➕ modem: add first support to fibocom fm160-eau on 3ginfo-lite & `modemband` package by @SuperKali  
+- 🐛 `linkup-optimization`: fix locatime by timezone by @SuperKali  
+
+### 🍌 BananaWRT Core
+
+- 🔼 build(deps): bump softprops/action-gh-release from 2.2.2 to 2.3.2 (#77) by @dependabot[bot]  
+
+---
+
 ## [2025-06-08]
 
 ### 🧩 Additional Packages
@@ -225,4 +239,4 @@ All notable changes to **BananaWRT** will be documented in this file.
 ---
 
 🛠️ Maintained with ❤️ by [BananaWRT](https://github.com/SuperKali/BananaWRT)  
-📅 Release date: **June 08, 2025**
+📅 Release date: **June 19, 2025**


### PR DESCRIPTION
This PR automatically updates the CHANGELOG.md with the latest changes.

## Changes included:
- Additions from BananaWRT core repository
- Additions from openwrt-packages repository

Please review the changes to ensure they're correctly formatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new changelog entry for the 2025-06-19 release, detailing recent updates and bug fixes.
	- Updated the release date in the changelog to June 19, 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->