### PR TITLE
fix(sdk): support oldstable track in SDK builder + trigger

### DIFF
--- a/.github/workflows/immortalwrt-sdk-matrix-builder.yml
+++ b/.github/workflows/immortalwrt-sdk-matrix-builder.yml
@@ -17,6 +17,7 @@ on:
         type: choice
         options:
           - stable
+          - oldstable
           - nightly
         default: stable
       architecture:
@@ -146,11 +147,14 @@ jobs:
         id: resolve
         run: |
           VL="v$(echo '${{ matrix.version }}' | grep -oP '^\d+\.\d+')"
-          if [ -f "config/${VL}/stable/.config" ]; then
-            TRACK="stable"
-          elif [ -f "config/${VL}/nightly/.config" ]; then
-            TRACK="nightly"
-          else
+          TRACK=""
+          for t in stable oldstable nightly; do
+            if [ -f "config/${VL}/${t}/.config" ]; then
+              TRACK="$t"
+              break
+            fi
+          done
+          if [ -z "$TRACK" ]; then
             echo "::error::No config found for ${VL}"
             exit 1
           fi

--- a/.github/workflows/immortalwrt-sdk-trigger.yml
+++ b/.github/workflows/immortalwrt-sdk-trigger.yml
@@ -29,13 +29,22 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        # Trigger SDK build for each active track that was changed
+        # Trigger an SDK build for each active track served by a mainline
+        # ImmortalWRT line. Fork-based variants (e.g. mtk-vendor) are skipped:
+        # the SDK matrix builds from upstream releases, not the rebase fork.
         for vf in config/*/version.json; do
           status=$(jq -r '.status' "$vf")
           [ "$status" != "active" ] && continue
 
           tracks=$(jq -r '.tracks[]' "$vf")
           for track in $tracks; do
+            case "$track" in
+              stable|oldstable|nightly) ;;
+              *)
+                echo "Skipping unsupported SDK track: $track"
+                continue
+                ;;
+            esac
             echo "Triggering SDK build for track: $track"
             gh workflow run immortalwrt-sdk-matrix-builder.yml \
               -f release_type="$track" \


### PR DESCRIPTION
## Problem

After promoting v24.10 to the new **oldstable** track, the SDK trigger fails:

```
Triggering SDK build for track: oldstable
could not create workflow dispatch event: HTTP 422: Provided value 'oldstable'
for input 'release_type' not in the list of allowed values
```

Two latent issues surfaced:
1. `immortalwrt-sdk-matrix-builder.yml` `release_type` choice only allowed `stable`/`nightly` → 422 on `oldstable`.
2. Its per-version track resolver probed only `stable` then `nightly` config dirs → would error `No config found` for v24.10 (now `oldstable/.config`).
3. `immortalwrt-sdk-trigger.yml` loops **all** active tracks, including the `mtk-vendor` fork variant, which this upstream-release SDK matrix can't build (would 422 too, right after `oldstable`).

## Fix

- Add `oldstable` to the SDK matrix `release_type` choice options.
- Resolve the track by probing `stable | oldstable | nightly` in order.
- Trigger now dispatches only mainline tracks (`stable`/`oldstable`/`nightly`) and explicitly skips fork-based tracks like `mtk-vendor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `oldstable` as a selectable release type option for workflow builds.

* **Improvements**
  * Enhanced build track detection to recognize and support the `oldstable` track alongside existing `stable` and `nightly` options.
  * Improved SDK build filtering to skip unsupported tracks and focus on active ImmortalWRT releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperKali/BananaWRT/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->