### PR TITLE
fix(ci): expose /usr/include/asm on arm64 for clang -target bpf (xdp-tools)

### DIFF
--- a/.github/scripts/setup-env.sh
+++ b/.github/scripts/setup-env.sh
@@ -288,6 +288,28 @@ if [ "$ACTION" == "setup" ]; then
         error "Unknown architecture: $ARCH"
         exit 1
     fi
+
+    # xdp-tools builds its BPF objects with `clang -target bpf`, which pulls in
+    # the host's <asm/types.h> via /usr/include/linux/types.h but does NOT search
+    # the Debian multiarch dir where those headers live (/usr/include/<triplet>/asm).
+    # On x86_64 gcc-multilib provides a bare /usr/include/asm; arm64 has no such
+    # package, so the BPF compile fails with "fatal error: 'asm/types.h' file not
+    # found". Expose the arch asm headers at the bare path. Idempotent.
+    section "Ensuring /usr/include/asm for clang -target bpf"
+    if [ "$DRY_RUN" = false ]; then
+        triplet="$(gcc -dumpmachine 2>/dev/null || echo "")"
+        if [ -e /usr/include/asm ]; then
+            [ "$VERBOSE" = true ] && info "/usr/include/asm already present"
+        elif [ -n "$triplet" ] && [ -d "/usr/include/$triplet/asm" ]; then
+            sudo ln -sfn "/usr/include/$triplet/asm" /usr/include/asm && \
+                success "Linked /usr/include/asm -> /usr/include/$triplet/asm" || \
+                error "Failed to link /usr/include/asm"
+        else
+            error "Could not locate asm headers for triplet '${triplet:-unknown}'"
+        fi
+    else
+        info "[DRY RUN] Would ensure /usr/include/asm symlink"
+    fi
 elif [ "$ACTION" == "clean" ]; then
     section "Cleaning up common packages"
     show_package_stats "$COMMON_PACKAGES" "clean"


### PR DESCRIPTION
## Problem

The 25.12.0 SDK build fails on the **ARM64** self-hosted runner while building `xdp-tools`:

```
/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found
    #include <asm/types.h>
```

xdp-tools compiles its BPF objects with `clang -target bpf`, which pulls in the host `<asm/types.h>` (via `/usr/include/linux/types.h`) but does **not** search the Debian multiarch dir where those headers live (`/usr/include/<triplet>/asm`).

X64 passes because `setup-env.sh` installs `gcc-multilib` (in `X86_64_PACKAGES`), which provides a bare `/usr/include/asm`. arm64 has no `gcc-multilib` equivalent, so the bare path is missing.

## Fix

In `setup-env.sh`, after the arch package install, symlink the arch asm headers (already installed via `libc6-dev`/`linux-libc-dev`) to the bare path:

`/usr/include/asm -> /usr/include/$(gcc -dumpmachine)/asm`

Idempotent (skips if `/usr/include/asm` already exists), runs only on `setup`. Mirrors how the x86 path already works rather than carrying a version-specific xdp-tools package patch.

Refs: openwrt/openwrt#12239, openwrt/openwrt#10223, xdp-project/xdp-tools#4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build environment setup to automatically configure necessary symlinks and headers for eBPF-based tools compilation, with improved error handling for missing dependencies and dry-run mode support for safer initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperKali/BananaWRT/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->