### PR TITLE
docs: Update CHANGELOG for 2026-09-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to **BananaWRT** will be documented in this file.
 
 ---
+## [2026-09-04]
+
+### 🧩 Additional Packages
+
+- 🐛 fix(quectel-cm): detect qmap mux netcard (wwanx_1) in netifd proto by @SuperKali  
+- 🐛 fix(`luci-app-3ginfo`-lite): expose 5g nr signal for quectel rm502q in nsa by @SuperKali  
+- 🐛 fix(`luci-app-3ginfo`-lite): report temperature on fibocom fm150/fm160/fm170 by @SuperKali  
+
+### 🍌 BananaWRT Core
+
+- 🔼 build(deps): bump actions/setup-python from 6 to 7 by @dependabot[bot]  
+
+---
+
 ## [2026-07-09]
 
 ### 🧩 Additional Packages
@@ -606,4 +620,4 @@ All notable changes to **BananaWRT** will be documented in this file.
 ---
 
 🛠️ Maintained with ❤️ by [BananaWRT](https://github.com/SuperKali/BananaWRT)  
-📅 Release date: **July 09, 2026**
+📅 Release date: **September 04, 2026**


### PR DESCRIPTION
This PR automatically updates the CHANGELOG.md with the latest changes.

## Changes included:
- Additions from BananaWRT core repository
- Additions from openwrt-packages repository

Please review the changes to ensure they're correctly formatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Quectel QMAP mux and netcard detection.
  * Added 5G NR signal reporting for Quectel RM502Q in NSA mode.
  * Added temperature reporting for Fibocom FM150, FM160, and FM170 modems.

* **Documentation**
  * Updated the changelog with the September 4, 2026 release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->